### PR TITLE
Improve GitHub stats workflow with PAT support

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -25,16 +25,23 @@ jobs:
 
       - name: 📈 Run collector
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPOS_TOKEN || secrets.GITHUB_TOKEN }}
           MIN_STARS    : ${{ vars.MIN_STARS    || '2'   }}
+          TARGET_REPOS : ${{ inputs.repos || vars.TARGET_REPOS || '' }}
         run: |
-          echo "TARGET_REPOS='${TARGET_REPOS}'"
-          python fetch_stats.py --commit
+          echo "Repos override: ${TARGET_REPOS}"
+          python fetch_stats.py
       
       - name: 📝 Build markdown dashboard
         run: |
           python generate_report.py
-          git add stats.md
+
+      - name: 💾 Commit snapshot
+        run: |
+          python - <<'PY'
+          from utils.git_utils import commit_if_changes
+          commit_if_changes()
+          PY
 
       - name: 🚀 Push (if commit created)
         run: |

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Want to track a different set? Just tell it!*
 
 1. **Fork** this repo to your personal account or org.  
 2. Enable **Actions** when GitHub prompts you.  
-3. *(Optional)* Open **Settings → Variables** and tweak:  
-   * `MIN_STARS` – raise/lower the auto-discover threshold (default **2**).  
-   * `TARGET_REPOS` – comma-separated list like  
+3. *(Optional)* Open **Settings → Variables** and tweak:
+   * `MIN_STARS` – raise/lower the auto-discover threshold (default **2**).
+   * `TARGET_REPOS` – comma-separated list like
      `owner1/repoA,owner2/repoB` (adds or replaces the auto list).
+4. *(Optional)* Add a Personal Access Token with `public_repo` scope as
+   secret **PUBLIC_REPOS_TOKEN** if you want to collect traffic stats for
+   other repositories you own.
 
 That’s it. The workflow runs every night at 00:07 UTC and appends one row per repo to `/data/*.csv`.  
 It also builds `/stats.md` as a lightweight dashboard of total/lifetime stats.
@@ -29,9 +32,11 @@ Run it straight away via **Actions → “📊 GitHub traffic snapshot” → Ru
 * **Track only certain repos** – set `TARGET_REPOS` (auto-discover still runs but the explicit list wins).  
 * **Include extra repos** – keep `TARGET_REPOS` empty and list them in `config.yml` instead; they’ll be *added* to the discovered set.  
 * **Change the schedule** – edit the `cron:` line in `.github/workflows/stats.yml`.  
-* **Stop committing from CI** – remove `--commit` in that same workflow step.
+* **Stop committing from CI** – remove the final commit step in the workflow.
 
-All configuration lives in **repo settings** – no secrets needed unless you push to other repos.
+All configuration lives in **repo settings**. The workflow uses
+`secrets.PUBLIC_REPOS_TOKEN` when present; otherwise it falls back to the
+default `GITHUB_TOKEN`, which can only see the current repository's traffic.
 
 ---
 
@@ -49,7 +54,7 @@ export MIN_STARS=1
 export TARGET_REPOS=you/special-repo
 
 # 3.  Snapshot!
-python fetch_stats.py           # add --commit to create a local git commit
+python fetch_stats.py
 
-# 4. Generate your markdown report 
+# 4. Generate your markdown report
 python generate_report.py

--- a/action.yml
+++ b/action.yml
@@ -27,12 +27,21 @@ runs:
         python-version: "3.12"
 
     - name: Run fetch_stats
-      run: python fetch_stats.py --commit
+      run: python fetch_stats.py
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         MIN_STARS: ${{ inputs.min_stars }}
+        TARGET_REPOS: ${{ inputs.target_repos }}
 
     - name: Generate markdown report
       run: python generate_report.py
+      shell: bash
+
+    - name: Commit snapshot
+      run: |
+        python - <<'PY'
+        from utils.git_utils import commit_if_changes
+        commit_if_changes()
+        PY
       shell: bash

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Dict, List
 
 from collectors.github import collect_repo, discover_repos
-from utils.git_utils import commit_if_changes
 
 ROOT      = Path(__file__).resolve().parent
 DATA_DIR  = ROOT / "data"
@@ -114,6 +113,10 @@ def main() -> None:
     if not token:
         raise SystemExit("❌ GITHUB_TOKEN is required (provided automatically in Actions)")
 
+    if os.getenv("GITHUB_ACTIONS") and os.getenv("GITHUB_REPOSITORY"):
+        print("ℹ️  Running in GitHub Actions")
+        print("   If cross-repo traffic stats are 0/403, set a PAT in secrets.PUBLIC_REPOS_TOKEN.")
+
     repos = get_target_repos(token)
     print(f"📈 Collecting stats for {', '.join(repos)}")
 
@@ -129,10 +132,6 @@ def main() -> None:
                 print(f"ℹ️  {full}: already had today’s snapshot")
         except Exception as exc:  # noqa: BLE001
             print(f"❌ {full}: {exc}")
-
-    # Commit if run with --commit and something changed
-    if "--commit" in sys.argv and new_rows:
-        commit_if_changes()
 
     # Non-zero exit if any repo failed
     if new_rows == 0:

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -11,9 +11,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def commit_if_changes(msg: str = "chore: update traffic data") -> None:
-    """Stage everything under data/ and commit if the tree is dirty."""
-    subprocess.run(["git", "add", "data"], cwd=ROOT, check=True)
+def commit_if_changes(msg: str = "chore: update stats snapshot") -> None:
+    """Stage CSV data and stats.md, then commit if the tree is dirty."""
+    subprocess.run(["git", "add", "data", "stats.md"], cwd=ROOT, check=True)
     dirty = subprocess.run(
         ["git", "diff", "--cached", "--quiet"],
         cwd=ROOT,


### PR DESCRIPTION
## Summary
- avoid hour-long sleeps by only retrying GitHub requests when truly rate-limited
- warn about default token use and support PAT/explicit repo list in workflow and action
- document PAT secret requirement for cross-repo traffic
- commit generated `stats.md` alongside CSVs so snapshot summary updates daily

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python generate_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdbb45153083289683e267cb15beb6